### PR TITLE
[CI] fix CI failures

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,8 +91,18 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: '${{ matrix.module }}/go.mod'
+      - name: seek out vulncheck
+        id: has-vulncheck
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          make -q vulncheck 2>/dev/null
+          echo "q=${?}" >> "${GITHUB_OUTPUT}"
       - run: make tools
+        if: steps.has-vulncheck.outputs.q != '2'
       - run: make vulncheck
+        if: steps.has-vulncheck.outputs.q != '2'
 
   lint-def:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -112,7 +112,10 @@ jobs:
           go-version-file: '${{ matrix.module }}/go.mod'
       - name: seek out lint-def
         id: has-lint-def
+        continue-on-error: true
+        shell: bash
         run: |
+          set +e
           make -q lint-def 2>/dev/null
           echo "q=${?}" >> "${GITHUB_OUTPUT}"
       - run: make tools


### PR DESCRIPTION
- `run:` の中が `sh -e` で動いており、終了コードを見て判定するコードが途中で止まってしまっていた([例](https://github.com/sacloud/sacloud-sdk-go/actions/runs/24722718887/job/72316103072))のの修正
- なんとモジュールによっては `make vulncheck` がない([例](https://github.com/sacloud/sacloud-sdk-go/actions/runs/24722683040/job/72316313484))という点を考慮
  - 実施した方が良いのは間違いないが、今後の課題とする