### PR TITLE
CI: minimal permission

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,8 @@ jobs:
       # Note that `dorny/paths-filter` itself runs without `actions/checkout`
       # but the `git ls-files` below mandates `.git` to exist.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: list submodules
         id: submodules
         run: >-
@@ -44,6 +46,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: sacloud/textlint-action@ffccb93746d1cf48d69b5da8ca79a64ca998f248 # v0.1.0
         with:
           working-directory: ${{ matrix.module }}
@@ -61,6 +65,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
@@ -83,6 +89,9 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       # Somehow `golang/govulncheck-action` does not make releases for years.
       # We just pin the commit SHA.
       - uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd
@@ -90,6 +99,7 @@ jobs:
           go-version-file: go.mod
           go-version-input: ''
           work-dir: ${{ matrix.module }}
+          repo-checkout: false
           output-format: sarif
           output-file: govulncheck.sarif
       - uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
@@ -111,6 +121,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
@@ -145,6 +157,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -139,6 +139,8 @@ jobs:
     defaults:
       run:
         working-directory: ${{ matrix.module }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,6 +107,8 @@ jobs:
     defaults:
       run:
         working-directory: ${{ matrix.module }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0


### PR DESCRIPTION
- `actions/checkout` がクレデンシャルをファイルに書いてしまう件 https://github.com/actions/checkout/issues/485 に対応します
  - 上記によると「そんなことしてもどうせActions自体がrootで動いてるんだからメモリ直接フルスキャンされたら結局ダメ」みたいなことが書いてあるわけですが、そうは言ってもファイルを読むのとではさすがに難易度が全然違うのでは…
- CodeQLから指摘を受けている二件に対応します
  - https://github.com/sacloud/sacloud-sdk-go/security/code-scanning/28
  - https://github.com/sacloud/sacloud-sdk-go/security/code-scanning/29
  - before: <img width="834" height="987" alt="permissions before merge" src="https://github.com/user-attachments/assets/2cd20eb9-16a5-461b-aafe-18d2d7151472" />
  - after: <img width="834" height="987" alt="permissions after merge" src="https://github.com/user-attachments/assets/cb64e47c-bdc3-4e1c-93cd-a9d29eedeb0b" />

