### PR TITLE
CI: give up lint-go at push

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,9 @@ jobs:
   lint-go:
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.changes != '[]'
+    if: >-
+      needs.changes.outputs.changes != '[]' &&
+      github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
- #161 の失敗しているテストはpushイベントのみで発生しておりpull_requestだと起きないようでした。