### PR TITLE
feat: add WithoutProfile option to disable profile loading

### DIFF
--- a/common/saclient/client_option.go
+++ b/common/saclient/client_option.go
@@ -166,6 +166,14 @@ func WithoutRetry() clientOption {
 	return WithCheckRetryFunc(disableRetry)
 }
 
+// WithoutProfile disables loading of usacloud-compatible profiles.
+func WithoutProfile() clientOption {
+	return func(c *Client) error {
+		c.params.noProfile = true
+		return nil
+	}
+}
+
 // WithDefaultTimeout sets default timeout for requests.
 // For each individual request, timeout can also be set using context.
 //

--- a/common/saclient/client_test.go
+++ b/common/saclient/client_test.go
@@ -660,6 +660,56 @@ func (s *ClientTestSuite) TestProfileWithNullValue() {
 	s.NotContains(actual, "Zones")
 }
 
+func (s *ClientTestSuite) TestWithoutProfile() {
+	xdg := os.Getenv("XDG_CONFIG_HOME")
+
+	s.Run("profile loaded by default", func() {
+		var subject Client
+		err := subject.SetEnviron([]string{"XDG_CONFIG_HOME=" + xdg})
+		s.NoError(err)
+		err = subject.Populate()
+		s.NoError(err)
+		s.Equal("usacloud", subject.JSON()["Zone"])
+	})
+
+	s.Run("WithoutProfile skips profile loading", func() {
+		var subject Client
+		err := subject.SetEnviron([]string{"XDG_CONFIG_HOME=" + xdg})
+		s.NoError(err)
+		err = subject.SetWith(WithoutProfile())
+		s.NoError(err)
+		err = subject.Populate()
+		s.NoError(err)
+		s.Nil(subject.JSON()["Zone"])
+	})
+
+	s.Run("WithoutProfile keeps environment variables", func() {
+		var subject Client
+		err := subject.SetEnviron([]string{
+			"XDG_CONFIG_HOME=" + xdg,
+			"SAKURACLOUD_ZONE=envzone",
+		})
+		s.NoError(err)
+		err = subject.SetWith(WithoutProfile())
+		s.NoError(err)
+		err = subject.Populate()
+		s.NoError(err)
+		s.Equal("envzone", subject.JSON()["Zone"])
+	})
+
+	s.Run("WithoutProfile ignores explicit --profile", func() {
+		var subject Client
+		err := subject.SetEnviron([]string{"XDG_CONFIG_HOME=" + xdg})
+		s.NoError(err)
+		err = subject.FlagSet(flag.PanicOnError).Parse([]string{"--profile=broken"})
+		s.NoError(err)
+		err = subject.SetWith(WithoutProfile())
+		s.NoError(err)
+		err = subject.Populate()
+		s.NoError(err)
+	})
+}
+
 func (s *ClientTestSuite) TestPrecedence() {
 	// Setup
 	subject := s.subject.Dup().(*Client)

--- a/common/saclient/parameter.go
+++ b/common/saclient/parameter.go
@@ -70,7 +70,7 @@ type storage struct {
 type config map[string]any
 
 type parameter struct {
-	// Deprecated: for compatibility
+	// Disable loading of usacloud-compatible profiles.
 	noProfile bool
 
 	// Deprecated: for compatibility


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

common/saclientにおいて明示的にプロファイルの読み込みをしないオプション `WithoutProfile()`を追加する

従来からある機能だが、api-client-goとの互換性維持のための機能という位置付けでDeprecated扱いだった
このPRではオプションを追加し、Deprecatedを解除して正式な機能とした

まずはgoのコードからの変更のみサポートしており、環境変数経由など他の機能はサポートしてない。
これらは今後必要になってから追加する。

### ドキュメントの変更は必要ですか？

no