### PR TITLE
toolchain go1.26.5

### DIFF
--- a/api/iaas/trace/otel/go.mod
+++ b/api/iaas/trace/otel/go.mod
@@ -2,7 +2,7 @@ module github.com/sacloud/sacloud-sdk-go/api/iaas/trace/otel
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/sacloud/sacloud-sdk-go/api/iaas v0.0.0-20260519024208-f2eaed9d3ae9

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sacloud/sacloud-sdk-go
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 tool github.com/ogen-go/ogen/cmd/ogen
 

--- a/go.work
+++ b/go.work
@@ -3,7 +3,7 @@
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 use (
 	.


### PR DESCRIPTION
govulncheckがいくつか警告を出しており、バージョンを上げることにします