### PR TITLE
add: expose DefaultZone via EndpointConfig()

### DIFF
--- a/common/saclient/client.go
+++ b/common/saclient/client.go
@@ -424,6 +424,16 @@ func (c *Client) EndpointConfig() (*EndpointConfig, error) {
 		ret.APIRootURL = url
 	}
 
+	defaultZone, ok, err := obtainFromConfig[string](cfg, "DefaultZone").decompose()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if ok {
+		ret.DefaultZone = defaultZone
+	}
+
 	return ret, nil
 }
 func (c *Client) ensurePopulated() (*config, error) {

--- a/common/saclient/endpoint.go
+++ b/common/saclient/endpoint.go
@@ -36,4 +36,12 @@ type EndpointConfig struct {
 	//
 	// Deprecated: Do not use. Kept only for compatibility.
 	APIRootURL string
+
+	// DefaultZone is the default zone used to access global resources.
+	//
+	// In IaaS API, some resources are global (not zone-scoped) but still
+	// need a zone context. This value tells which zone to use in such cases.
+	//
+	// Deprecated: Do not use. Kept only for compatibility.
+	DefaultZone string
 }

--- a/common/saclient/endpoint_test.go
+++ b/common/saclient/endpoint_test.go
@@ -179,6 +179,104 @@ func (this *endpointTest) TestEndpointConfig_EnvOverridesProfile() {
 	this.Equal("https://env.example.com/cloud/zone", cfg.Endpoints["iaas"])
 }
 
+func (this *endpointTest) TestEndpointConfig_DefaultZone_FromEnv() {
+	this.setEnv("SAKURA_ACCESS_TOKEN", "test-token")
+	this.setEnv("SAKURA_ACCESS_TOKEN_SECRET", "test-secret")
+	this.setEnv("SAKURA_DEFAULT_ZONE", "tk1a")
+
+	var client Client
+	err := client.SetEnviron(os.Environ())
+	this.NoError(err)
+
+	api, err := client.DupWith(WithTestServer(this.testServer))
+	this.NoError(err)
+
+	err = api.Populate()
+	this.NoError(err)
+
+	cfg, err := api.EndpointConfig()
+	this.NoError(err)
+	this.NotNil(cfg)
+	this.Equal("tk1a", cfg.DefaultZone)
+}
+
+func (this *endpointTest) TestEndpointConfig_DefaultZone_FromProfile() {
+	defer func() {
+		_ = os.RemoveAll(os.TempDir() + "/test-profiles-override")
+		_ = os.Unsetenv("XDG_CONFIG_HOME")
+	}()
+
+	profileDir := os.TempDir() + "/test-profiles-override"
+	_ = os.MkdirAll(profileDir+"/usacloud/default", 0700)
+
+	profileContent := `{
+  "AccessToken": "test-token",
+  "AccessTokenSecret": "test-secret",
+  "DefaultZone": "is1b"
+}`
+
+	this.setEnv("SAKURA_PROFILE", "default")
+	this.setEnv("XDG_CONFIG_HOME", profileDir)
+	_ = os.WriteFile(profileDir+"/usacloud/default/config.json", []byte(profileContent), 0600)
+
+	_ = os.Unsetenv("SAKURA_DEFAULT_ZONE")
+
+	var client Client
+	err := client.SetEnviron(os.Environ())
+	this.NoError(err)
+
+	api, err := client.DupWith(WithTestServer(this.testServer))
+	this.NoError(err)
+
+	err = api.Populate()
+	this.NoError(err)
+
+	cfg, err := api.EndpointConfig()
+	this.NoError(err)
+	this.NotNil(cfg)
+	this.Equal("is1b", cfg.DefaultZone)
+}
+
+func (this *endpointTest) TestEndpointConfig_DefaultZone_EnvOverridesProfile() {
+	defer func() {
+		_ = os.RemoveAll(os.TempDir() + "/test-profiles-override")
+		_ = os.Unsetenv("XDG_CONFIG_HOME")
+	}()
+
+	profileDir := os.TempDir() + "/test-profiles-override"
+	_ = os.MkdirAll(profileDir+"/usacloud/default", 0700)
+
+	profileContent := `{
+  "AccessToken": "test-token",
+  "AccessTokenSecret": "test-secret",
+  "DefaultZone": "is1b"
+}`
+
+	this.setEnv("SAKURA_PROFILE", "default")
+	this.setEnv("XDG_CONFIG_HOME", profileDir)
+	_ = os.WriteFile(profileDir+"/usacloud/default/config.json", []byte(profileContent), 0600)
+
+	this.setEnv("SAKURA_DEFAULT_ZONE", "tk1a")
+	this.setEnv("SAKURA_ACCESS_TOKEN", "test-token")
+	this.setEnv("SAKURA_ACCESS_TOKEN_SECRET", "test-secret")
+
+	var client Client
+	err := client.SetEnviron(os.Environ())
+	this.NoError(err)
+
+	api, err := client.DupWith(WithTestServer(this.testServer))
+	this.NoError(err)
+
+	err = api.Populate()
+	this.NoError(err)
+
+	cfg, err := api.EndpointConfig()
+	this.NoError(err)
+	this.NotNil(cfg)
+	// Environment variable should override profile
+	this.Equal("tk1a", cfg.DefaultZone)
+}
+
 func TestEndpointSuite(t *testing.T) {
 	suite.Run(t, new(endpointTest))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

さくらのクラウドにはアイコンやDNS、GSLBなどの全ゾーン共通のグローバルリソースというのがありますが、APIを叩くときにはなんらかのゾーンを指定する必要があり、従来は環境変数 `SAKURA[CLOUD]_DEFAULT_ZONE` やProfileの `DefaultZone`でその値を指定可能でした

しかしこの値についてsaclientでは環境変数などの各種の入力を評価した最終的な値を知る手段がなく、この値を利用するAPIクライアント、とくにiaas-api-goを直接使っているケースでsaclientへの移行の障壁になっています。

saclientではすでに EndpointConfigというstructでこのような値を公開しているため、そこにフィールドを追加して対応しました。
参考: https://pkg.go.dev/github.com/sacloud/sacloud-sdk-go@v0.0.1/common/saclient#EndpointConfig

なお、今回は互換性維持のために `DefaultZone`という名前のフィールドにしましたが、この名前は誤解を招きやすく将来的に変更したいと思っています。

このため今回は追加したフィールドをDeprecatedにしておき、互換性維持の目的以外で使わないようにマークしています。 (EndpointConfigの他のフィールドと揃えてます)


### ドキュメントの変更は必要ですか？

no