### PR TITLE
[CI] speed up

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: ["main"]
 
 jobs:
   changes:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -134,5 +134,4 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
-      - run: make tools
       - run: make test


### PR DESCRIPTION
これ以外にももっと色々な最適化が考えられるとは思いますが、とりあえず狙える low hanging fruit ということで

- push時CIの削減(mainだけにする)
- `make tools`のスキップ

を一旦試したいなと。