### PR TITLE
Fix fake ProxyLB certificate mapping

### DIFF
--- a/api/iaas/fake/ops_proxy_lb.go
+++ b/api/iaas/fake/ops_proxy_lb.go
@@ -215,7 +215,13 @@ func (o *ProxyLBOp) SetCertificates(ctx context.Context, id types.ID, param *iaa
 	}
 
 	cert := &iaas.ProxyLBCertificates{}
-	copySameNameField(param, cert)
+	copySameNameField(&struct {
+		PrimaryCert     *iaas.ProxyLBPrimaryCert
+		AdditionalCerts []*iaas.ProxyLBAdditionalCert
+	}{
+		PrimaryCert:     param.PrimaryCerts,
+		AdditionalCerts: param.AdditionalCerts,
+	}, cert)
 	cert.PrimaryCert.CertificateCommonName = "dummy-common-name.org"
 	cert.PrimaryCert.CertificateEndDate = time.Now().Add(365 * 24 * time.Hour)
 

--- a/api/iaas/fake/ops_proxy_lb.go
+++ b/api/iaas/fake/ops_proxy_lb.go
@@ -222,6 +222,9 @@ func (o *ProxyLBOp) SetCertificates(ctx context.Context, id types.ID, param *iaa
 		PrimaryCert:     param.PrimaryCerts,
 		AdditionalCerts: param.AdditionalCerts,
 	}, cert)
+	if cert.PrimaryCert == nil {
+		cert.PrimaryCert = &iaas.ProxyLBPrimaryCert{}
+	}
 	cert.PrimaryCert.CertificateCommonName = "dummy-common-name.org"
 	cert.PrimaryCert.CertificateEndDate = time.Now().Add(365 * 24 * time.Hour)
 

--- a/api/iaas/fake/ops_proxy_lb_test.go
+++ b/api/iaas/fake/ops_proxy_lb_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The sacloud/iaas-api-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sacloud/sacloud-sdk-go/api/iaas"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyLBOpSetCertificates(t *testing.T) {
+	// Exercise the public factory path where PrimaryCerts must populate the
+	// differently named PrimaryCert field in the fake response.
+	SwitchFactoryFuncToFake()
+
+	ctx := context.Background()
+	op := iaas.NewProxyLBOp(nil)
+	proxyLB, err := op.Create(ctx, &iaas.ProxyLBCreateRequest{})
+	require.NoError(t, err)
+
+	request := &iaas.ProxyLBSetCertificatesRequest{
+		PrimaryCerts: &iaas.ProxyLBPrimaryCert{
+			ServerCertificate:       "server-certificate",
+			IntermediateCertificate: "intermediate-certificate",
+			PrivateKey:              "private-key",
+		},
+	}
+	certificates, err := op.SetCertificates(ctx, proxyLB.ID, request)
+	require.NoError(t, err)
+	require.NotNil(t, certificates.PrimaryCert)
+	require.Equal(t, request.PrimaryCerts.ServerCertificate, certificates.PrimaryCert.ServerCertificate)
+	require.Equal(t, request.PrimaryCerts.IntermediateCertificate, certificates.PrimaryCert.IntermediateCertificate)
+	require.Equal(t, request.PrimaryCerts.PrivateKey, certificates.PrimaryCert.PrivateKey)
+	require.Equal(t, "dummy-common-name.org", certificates.PrimaryCert.CertificateCommonName)
+	require.False(t, certificates.PrimaryCert.CertificateEndDate.IsZero())
+
+	stored, err := op.GetCertificates(ctx, proxyLB.ID)
+	require.NoError(t, err)
+	require.Equal(t, certificates, stored)
+}

--- a/api/iaas/fake/ops_proxy_lb_test.go
+++ b/api/iaas/fake/ops_proxy_lb_test.go
@@ -1,16 +1,5 @@
 // Copyright 2026 The sacloud/iaas-api-go Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package fake
 

--- a/api/iaas/fake/ops_proxy_lb_test.go
+++ b/api/iaas/fake/ops_proxy_lb_test.go
@@ -52,3 +52,18 @@ func TestProxyLBOpSetCertificates(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, certificates, stored)
 }
+
+func TestProxyLBOpSetCertificatesWithoutPrimaryCert(t *testing.T) {
+	SwitchFactoryFuncToFake()
+
+	ctx := context.Background()
+	op := iaas.NewProxyLBOp(nil)
+	proxyLB, err := op.Create(ctx, &iaas.ProxyLBCreateRequest{})
+	require.NoError(t, err)
+
+	certificates, err := op.SetCertificates(ctx, proxyLB.ID, &iaas.ProxyLBSetCertificatesRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, certificates.PrimaryCert)
+	require.Equal(t, "dummy-common-name.org", certificates.PrimaryCert.CertificateCommonName)
+	require.False(t, certificates.PrimaryCert.CertificateEndDate.IsZero())
+}


### PR DESCRIPTION
## 概要

fakeドライバの `ProxyLBOp.SetCertificates` で、リクエストの `PrimaryCerts` を応答の `PrimaryCert` へ正しく反映するよう修正しました。

## 変更内容

- `PrimaryCerts` と `PrimaryCert` の異なるフィールド名を明示的に対応付け
- fake factory経由で `iaas.NewProxyLBOp(nil).SetCertificates` を呼ぶ回帰テストを追加

## 修正理由

従来はJSON経由の同名フィールドコピーにより `PrimaryCerts` がコピーされず、`cert.PrimaryCert` が nil のまま証明書メタデータを設定してpanicしていました。

## 動作確認

- 修正前: 追加した回帰テストが nil ポインタ参照panicで失敗
- 修正後: `go test ./api/iaas/fake` が成功