### PR TITLE
iaas: add Ubuntu 26.04 to ostype

### DIFF
--- a/api/iaas/ostype/archive_ostype.go
+++ b/api/iaas/ostype/archive_ostype.go
@@ -51,6 +51,8 @@ const (
 
 	// Ubuntu OS種別:Ubuntu
 	Ubuntu
+	// Ubuntu2604 OS種別:Ubuntu
+	Ubuntu2604
 	// Ubuntu2404 OS種別:Ubuntu
 	Ubuntu2404
 	// Ubuntu2204 OS種別:Ubuntu(Jammy Jellyfish)
@@ -81,6 +83,7 @@ var ArchiveOSTypes = []ArchiveOSType{
 	MiracleLinux9,
 	MiracleLinux8,
 	Ubuntu,
+	Ubuntu2604,
 	Ubuntu2404,
 	Ubuntu2204,
 	Debian,
@@ -94,7 +97,7 @@ var OSTypeShortNames = []string{
 	"almalinux", "almalinux10", "almalinux9", "almalinux8",
 	"rockylinux", "rockylinux10", "rockylinux9", "rockylinux8",
 	"miracle", "miraclelinux", "miracle9", "miraclelinux9", "miracle8", "miraclelinux8",
-	"ubuntu", "ubuntu2404", "ubuntu2204",
+	"ubuntu", "ubuntu2604", "ubuntu2404", "ubuntu2204",
 	"debian", "debian12", "debian11",
 	"kusanagi",
 }
@@ -106,7 +109,7 @@ func (o ArchiveOSType) IsSupportDiskEdit() bool {
 		AlmaLinux, AlmaLinux10, AlmaLinux9, AlmaLinux8,
 		RockyLinux, RockyLinux10, RockyLinux9, RockyLinux8,
 		MiracleLinux, MiracleLinux9, MiracleLinux8,
-		Ubuntu, Ubuntu2404, Ubuntu2204,
+		Ubuntu, Ubuntu2604, Ubuntu2404, Ubuntu2204,
 		Debian, Debian12, Debian11,
 		Kusanagi:
 		return true
@@ -142,6 +145,8 @@ func StrToOSType(osType string) ArchiveOSType {
 		return MiracleLinux8
 	case "ubuntu":
 		return Ubuntu
+	case "ubuntu2604":
+		return Ubuntu2604
 	case "ubuntu2404":
 		return Ubuntu2404
 	case "ubuntu2204":

--- a/api/iaas/ostype/archiveostype_string.go
+++ b/api/iaas/ostype/archiveostype_string.go
@@ -35,17 +35,18 @@ func _() {
 	_ = x[MiracleLinux9-10]
 	_ = x[MiracleLinux8-11]
 	_ = x[Ubuntu-12]
-	_ = x[Ubuntu2404-13]
-	_ = x[Ubuntu2204-14]
-	_ = x[Debian-15]
-	_ = x[Debian12-16]
-	_ = x[Debian11-17]
-	_ = x[Kusanagi-18]
+	_ = x[Ubuntu2604-13]
+	_ = x[Ubuntu2404-14]
+	_ = x[Ubuntu2204-15]
+	_ = x[Debian-16]
+	_ = x[Debian12-17]
+	_ = x[Debian11-18]
+	_ = x[Kusanagi-19]
 }
 
-const _ArchiveOSType_name = "CustomAlmaLinuxAlmaLinux10AlmaLinux9AlmaLinux8RockyLinuxRockyLinux10RockyLinux9RockyLinux8MiracleLinuxMiracleLinux9MiracleLinux8UbuntuUbuntu2404Ubuntu2204DebianDebian12Debian11Kusanagi"
+const _ArchiveOSType_name = "CustomAlmaLinuxAlmaLinux10AlmaLinux9AlmaLinux8RockyLinuxRockyLinux10RockyLinux9RockyLinux8MiracleLinuxMiracleLinux9MiracleLinux8UbuntuUbuntu2604Ubuntu2404Ubuntu2204DebianDebian12Debian11Kusanagi"
 
-var _ArchiveOSType_index = [...]uint8{0, 6, 15, 26, 36, 46, 56, 68, 79, 90, 102, 115, 128, 134, 144, 154, 160, 168, 176, 184}
+var _ArchiveOSType_index = [...]uint8{0, 6, 15, 26, 36, 46, 56, 68, 79, 90, 102, 115, 128, 134, 144, 154, 164, 170, 178, 186, 194}
 
 func (i ArchiveOSType) String() string {
 	idx := int(i) - 0

--- a/api/iaas/ostype/filter_criteria.go
+++ b/api/iaas/ostype/filter_criteria.go
@@ -70,6 +70,10 @@ var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 		search.Key(keys.Tags):  search.TagsAndEqual("current-stable", "distro-ubuntu"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
 	},
+	Ubuntu2604: {
+		search.Key(keys.Tags):  search.TagsAndEqual("ubuntu-26.04-latest"),
+		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),
+	},
 	Ubuntu2404: {
 		search.Key(keys.Tags):  search.TagsAndEqual("ubuntu-24.04-latest"),
 		search.Key(keys.Scope): search.ExactMatch(types.Scopes.Shared.String()),


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

さくらのクラウドで公開された Ubuntu 26.04 のパブリックアーカイブを `ostype` に追加する。

変更内容:
- `api/iaas/ostype/archive_ostype.go` に `Ubuntu2604` を追加
- `api/iaas/ostype/filter_criteria.go` に検索条件（タグ `ubuntu-26.04-latest`）を追加
- `go generate` で `archiveostype_string.go` を再生成

### ドキュメントの変更は必要ですか？

不要