### PR TITLE
[CI] dependabot groups for otel updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -25,5 +25,10 @@ updates:
       timezone: "Asia/Tokyo"
     commit-message:
       prefix: "go:"
+    groups:
+      otel:
+        applies-to: version-updates
+        patterns:
+          - go.opentelemetry.io/*
     cooldown:
       default-days: 7


### PR DESCRIPTION
なんかdependabot version updatesが止まっちゃったんですよ

<img width="928" height="674" alt="Capture 2026-08-14 at 14 26 42" src="https://github.com/user-attachments/assets/f8551ddf-24e2-4081-b076-c500bffb8e33" />

理由は

> Dependabot cannot open any more pull requests

なんですって。

で、もちろんリミット解除するとかは選択肢あるんですけど、それはそれでプルリクエストがバーって生成されるのもどうかなって思うじゃないですか?

でもhttps://github.com/sacloud/sacloud-sdk-go/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies dependabotのプルリクエスト見ると、なんかotelの更新が半分くらいあるのでは?

それらは一つにまとめていいんじゃないでしょうか。