### PR TITLE
api/eventbus: fix Provider.Class filter query injection

### DIFF
--- a/api/eventbus/client_test.go
+++ b/api/eventbus/client_test.go
@@ -28,12 +28,14 @@
 package eventbus_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
 
 	. "github.com/sacloud/sacloud-sdk-go/api/eventbus"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/eventbus/apis/v1"
 	"github.com/sacloud/sacloud-sdk-go/common/saclient"
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +70,54 @@ func TestNewClient_WithCustomEndpoint(t *testing.T) {
 	assert.Len(requests, 1)
 }
 
+func TestNewClient_InjectFilterQuery(t *testing.T) {
+	assert := require.New(t)
+
+	tracker := newMockRequestTracker()
+	defer tracker.Close()
+
+	var theClient saclient.Client
+	err := theClient.SetEnviron([]string{"SAKURA_ENDPOINTS_EVENTBUS=" + tracker.URL()})
+	assert.NoError(err)
+
+	client, err := NewClient(&theClient)
+	assert.NoError(err)
+	assert.NotNil(client)
+
+	cases := []struct {
+		name     string
+		list     func(context.Context) ([]v1.CommonServiceItem, error)
+		expected string
+	}{
+		{
+			name:     "ProcessConfiguration",
+			list:     NewProcessConfigurationOp(client).List,
+			expected: `{"Filter":{"Provider.Class":"eventbusprocessconfiguration"}}`,
+		},
+		{
+			name:     "Schedule",
+			list:     NewScheduleOp(client).List,
+			expected: `{"Filter":{"Provider.Class":"eventbusschedule"}}`,
+		},
+		{
+			name:     "Trigger",
+			list:     NewTriggerOp(client).List,
+			expected: `{"Filter":{"Provider.Class":"eventbustrigger"}}`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker.Reset()
+			_, _ = tt.list(t.Context())
+
+			requests := tracker.Requests()
+			assert.Len(requests, 1)
+			assert.Equal(tt.expected, requests[0].URL.RawQuery)
+		})
+	}
+}
+
 type mockRequestTracker struct {
 	mu       sync.Mutex
 	requests []*http.Request
@@ -98,6 +148,12 @@ func (m *mockRequestTracker) Close() {
 
 func (m *mockRequestTracker) URL() string {
 	return m.server.URL
+}
+
+func (m *mockRequestTracker) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requests = m.requests[:0]
 }
 
 func (m *mockRequestTracker) Requests() []*http.Request {

--- a/api/eventbus/client_test.go
+++ b/api/eventbus/client_test.go
@@ -64,7 +64,8 @@ func TestNewClient_WithCustomEndpoint(t *testing.T) {
 	assert.NotNil(client)
 
 	op := NewProcessConfigurationOp(client)
-	_, _ = op.List(t.Context())
+	_, err = op.List(t.Context())
+	assert.NoError(err)
 
 	requests := tracker.Requests()
 	assert.Len(requests, 1)
@@ -109,7 +110,8 @@ func TestNewClient_InjectFilterQuery(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			tracker.Reset()
-			_, _ = tt.list(t.Context())
+			_, err := tt.list(t.Context())
+			assert.NoError(err)
 
 			requests := tracker.Requests()
 			assert.Len(requests, 1)
@@ -129,6 +131,13 @@ func (m *mockRequestTracker) handler() http.HandlerFunc {
 		m.mu.Lock()
 		m.requests = append(m.requests, r)
 		m.mu.Unlock()
+
+		if r.Method == http.MethodGet && r.URL.Path == "/commonserviceitem" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"CommonServiceItems":[]}`))
+			return
+		}
 
 		w.WriteHeader(http.StatusNoContent)
 	}

--- a/api/eventbus/filter.go
+++ b/api/eventbus/filter.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	v1 "github.com/sacloud/sacloud-sdk-go/api/eventbus/apis/v1"
 	"github.com/sacloud/sacloud-sdk-go/common/saclient"
@@ -31,6 +32,10 @@ func injectFilterMiddleware(apiRootURL string) (saclient.Middleware, error) {
 		return nil, err
 	}
 	listAPIPath := u.JoinPath("/commonserviceitem").Path
+	// apiRootURL の Path が空の場合、JoinPath が先頭の "/" を削ることがあるため正規化
+	if !strings.HasPrefix(listAPIPath, "/") {
+		listAPIPath = "/" + listAPIPath
+	}
 
 	return func(req *http.Request, pull func() (saclient.Middleware, bool)) (*http.Response, error) {
 		injectFilterToRequest(req, listAPIPath)

--- a/api/eventbus/list_filter_test.go
+++ b/api/eventbus/list_filter_test.go
@@ -1,0 +1,104 @@
+package eventbus_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	eventbus "github.com/sacloud/sacloud-sdk-go/api/eventbus"
+	v1 "github.com/sacloud/sacloud-sdk-go/api/eventbus/apis/v1"
+	"github.com/sacloud/sacloud-sdk-go/common/packages/testutil"
+	"github.com/sacloud/sacloud-sdk-go/common/saclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListFilterByProviderClass(t *testing.T) {
+	testutil.PreCheckEnvsFunc("SAKURA_ACCESS_TOKEN",
+		"SAKURA_ACCESS_TOKEN_SECRET", "SAKURA_SIMPLE_NOTIFICATION_GROUP_ID")(t)
+
+	var theClient saclient.Client
+	client, err := eventbus.NewClient(&theClient)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	pcOp := eventbus.NewProcessConfigurationOp(client)
+	schedOp := eventbus.NewScheduleOp(client)
+	triggerOp := eventbus.NewTriggerOp(client)
+	groupId := os.Getenv("SAKURA_SIMPLE_NOTIFICATION_GROUP_ID")
+
+	pc, err := pcOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name:        "SDK List Filter Test",
+			Description: v1.NewOptNilString("SDK List Filter Test"),
+			Tags:        []string{"test"},
+			Settings:    eventbus.CreateSimpleNotificationSettings(groupId, "メッセージ"),
+		},
+	})
+	require.NoError(t, err)
+	defer func() {
+		_ = pcOp.Delete(ctx, pc.ID)
+	}()
+
+	schedule, err := schedOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name:        "SDK List Filter Test",
+			Description: v1.NewOptNilString("SDK List Filter Test"),
+			Settings: v1.NewScheduleSettingsSettings(v1.ScheduleSettings{
+				ProcessConfigurationID: pc.ID,
+				RecurringStep:          v1.NewOptInt(5),
+				RecurringUnit:          v1.NewOptScheduleSettingsRecurringUnit(v1.ScheduleSettingsRecurringUnitMin),
+				StartsAt:               v1.NewInt64ScheduleSettingsStartsAt(time.Now().UnixMilli()),
+			}),
+		},
+	})
+	require.NoError(t, err)
+	defer func() {
+		_ = schedOp.Delete(ctx, schedule.ID)
+	}()
+
+	trigger, err := triggerOp.Create(ctx, v1.CreateCommonServiceItemRequest{
+		CommonServiceItem: v1.CreateCommonServiceItemRequestCommonServiceItem{
+			Name:        "SDK List Filter Test",
+			Description: v1.NewOptNilString("SDK List Filter Test"),
+			Settings: v1.NewTriggerSettingsSettings(v1.TriggerSettings{
+				ProcessConfigurationID: pc.ID,
+				Source:                 "//eventbus.sakura.ad.jp/test",
+				Types:                  v1.NewOptNilStringArray([]string{"test.instance.created"}),
+				Conditions: v1.NewOptNilTriggerSettingsConditionsItemArray([]v1.TriggerSettingsConditionsItem{
+					v1.NewTriggerConditionEqTriggerSettingsConditionsItem(v1.TriggerConditionEq{
+						Key:    "key1",
+						Op:     v1.TriggerConditionEqOpEq,
+						Values: []string{"value1"},
+					}),
+				}),
+			}),
+		},
+	})
+	require.NoError(t, err)
+	defer func() {
+		_ = triggerOp.Delete(ctx, trigger.ID)
+	}()
+
+	pcList, err := pcOp.List(ctx)
+	require.NoError(t, err)
+	for _, item := range pcList {
+		assert.True(t, item.Settings.IsProcessConfigurationSettings(),
+			"ProcessConfiguration.List returned non-ProcessConfiguration item: ID=%s", item.ID)
+	}
+
+	scheduleList, err := schedOp.List(ctx)
+	require.NoError(t, err)
+	for _, item := range scheduleList {
+		assert.True(t, item.Settings.IsScheduleSettings(),
+			"Schedule.List returned non-Schedule item: ID=%s", item.ID)
+	}
+
+	triggerList, err := triggerOp.List(ctx)
+	require.NoError(t, err)
+	for _, item := range triggerList {
+		assert.True(t, item.Settings.IsTriggerSettings(),
+			"Trigger.List returned non-Trigger item: ID=%s", item.ID)
+	}
+}


### PR DESCRIPTION
## 背景

eventbus API の Trigger/Schedule/ProcessConfiguration は同一の `GET /commonserviceitem` を共有しており、SDK 側が `?{"Filter":{"Provider.Class":"..."}}` というクエリを注入することで種別を絞り込んでいた。

`apiRootURL` の Path が空の場合（例: sakumock や `httptest.Server`）、`url.URL.JoinPath` が先頭の `/` を削ったパスを返すため、ミドルウェア内の一致判定が失敗し、クエリ注入がスキップされていた。

本番のデフォルトエンドポイント（`https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1`）では Path が空ではないため、実用上は問題がなかったが、sakumock でのテスト時に顕在化した。

## 修正

`filter.go` で `listAPIPath` が `/` で始まらない場合、先頭に `/` を補うように正規化した。

## テスト

- `client_test.go` に `RawQuery` が期待通り設定されていることを検証するユニットテストを追加
- `list_filter_test.go` に 3 種別のリソースを作成した状態で各 `List` API が他種別を混ぜずに返すことを検証する統合テストを追加

## 確認

```bash
go test ./api/eventbus/...
```

全テスト PASS。