### PR TITLE
s/スイッチ\+ルータ/ルータ+スイッチ/g

### DIFF
--- a/api/iaas/accessor/switch_subnet.go
+++ b/api/iaas/accessor/switch_subnet.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sacloud/sacloud-sdk-go/common/packages/cidr"
 )
 
-// AssignedIPAddress スイッチ+ルータの割り当てられたIPアドレスリスト
+// AssignedIPAddress ルータ+スイッチの割り当てられたIPアドレスリスト
 type AssignedIPAddress interface {
 	GetAssignedIPAddressMax() string
 	SetAssignedIPAddressMax(v string)

--- a/api/iaas/helper/cleanup/internet.go
+++ b/api/iaas/helper/cleanup/internet.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sacloud/sacloud-sdk-go/api/iaas/types"
 )
 
-// DeleteInternet スイッチ+ルータの削除 IPv6の無効化やサブネットの削除を一括して行う
+// DeleteInternet ルータ+スイッチの削除 IPv6の無効化やサブネットの削除を一括して行う
 func DeleteInternet(ctx context.Context, client iaas.InternetAPI, zone string, id types.ID) error {
 	internet, err := client.Read(ctx, zone, id)
 	if err != nil {

--- a/api/iaas/internal/define/apis.go
+++ b/api/iaas/internal/define/apis.go
@@ -53,7 +53,7 @@ func init() {
 	APIs.Define(gslbAPI)                          // GSLB
 	APIs.Define(iconAPI)                          // アイコン
 	APIs.Define(interfaceAPI)                     // インターフェース(NIC)
-	APIs.Define(internetAPI)                      // スイッチ+ルータ
+	APIs.Define(internetAPI)                      // ルータ+スイッチ
 	APIs.Define(internetPlanAPI)                  // ルータプラン
 	APIs.Define(ipAPI)                            // IPアドレス
 	APIs.Define(ipv6netAPI)                       // IPv6ネットワーク

--- a/api/iaas/internal/define/fields.go
+++ b/api/iaas/internal/define/fields.go
@@ -2376,7 +2376,7 @@ func (f *fieldsDef) NextHop() *dsl.FieldDesc {
 		Name: "NextHop",
 		Type: meta.TypeString,
 		Description: `
-			スイッチ+ルータでの追加IPアドレスブロックを示すSubnetの中でのみ設定される項目。
+			ルータ+スイッチでの追加IPアドレスブロックを示すSubnetの中でのみ設定される項目。
 			この場合DefaultRouteの値は設定されないためNextHopを代用する。
 			StaticRouteと同じ値が設定される。`,
 	}
@@ -2387,7 +2387,7 @@ func (f *fieldsDef) StaticRoute() *dsl.FieldDesc {
 		Name: "StaticRoute",
 		Type: meta.TypeString,
 		Description: `
-			スイッチ+ルータでの追加IPアドレスブロックを示すSubnetの中でのみ設定される項目。
+			ルータ+スイッチでの追加IPアドレスブロックを示すSubnetの中でのみ設定される項目。
 			この場合DefaultRouteの値は設定されないためNextHopを代用する。
 			NextHopと同じ値が設定される。`,
 	}

--- a/service/iaas/internet/builder/builder.go
+++ b/service/iaas/internet/builder/builder.go
@@ -24,10 +24,10 @@ import (
 	"github.com/sacloud/sacloud-sdk-go/api/iaas/types"
 )
 
-// DefaultNotFoundRetry スイッチ+ルータ作成後のReadで404が返ってこなくなるまでに許容する404エラーの回数
+// DefaultNotFoundRetry ルータ+スイッチ作成後のReadで404が返ってこなくなるまでに許容する404エラーの回数
 var DefaultNotFoundRetry = 360 // デフォルトの5秒おきリトライの場合30分
 
-// Builder スイッチ+ルータの構築を行う
+// Builder ルータ+スイッチの構築を行う
 type Builder struct {
 	Name           string
 	Description    string
@@ -106,7 +106,7 @@ func (b *Builder) Build(ctx context.Context, zone string) (*iaas.Internet, error
 	return b.Client.Internet.Read(ctx, zone, internet.ID)
 }
 
-// Update スイッチ+ルータの更新
+// Update ルータ+スイッチの更新
 func (b *Builder) Update(ctx context.Context, zone string, id types.ID) (*iaas.Internet, error) {
 	if err := b.Validate(ctx, zone); err != nil {
 		return nil, err

--- a/service/iaas/internet/create_request.go
+++ b/service/iaas/internet/create_request.go
@@ -34,7 +34,7 @@ type CreateRequest struct {
 	BandWidthMbps  int
 	EnableIPv6     bool
 	NoWait         bool
-	NotFoundRetry  int // スイッチ+ルータは作成直後だと404を返すことがあることへの対応でリトライする際のリトライ上限回数、省略時はDefaultNotFoundRetry
+	NotFoundRetry  int // ルータ+スイッチは作成直後だと404を返すことがあることへの対応でリトライする際のリトライ上限回数、省略時はDefaultNotFoundRetry
 }
 
 func (req *CreateRequest) Validate() error {

--- a/service/iaas/server/builder/example_test.go
+++ b/service/iaas/server/builder/example_test.go
@@ -80,9 +80,9 @@ func Example_builder() {
 					ChangePartitionUUID: true,                 // UUIDの変更
 					EnableDHCP:          false,                // DHCPの有効化
 
-					//IPAddress:                 "192.168.11.11",                    // IPアドレス(スイッチ or スイッチ+ルータに接続する場合)
-					//NetworkMaskLen:            24,                                 // ネットワークマスク長(スイッチ or スイッチ+ルータに接続する場合)
-					//DefaultRoute:              "192.168.11.1",                     // デフォルトルート(スイッチ or スイッチ+ルータに接続する場合)
+					//IPAddress:                 "192.168.11.11",                    // IPアドレス(スイッチ or ルータ+スイッチに接続する場合)
+					//NetworkMaskLen:            24,                                 // ネットワークマスク長(スイッチ or ルータ+スイッチに接続する場合)
+					//DefaultRoute:              "192.168.11.1",                     // デフォルトルート(スイッチ or ルータ+スイッチに接続する場合)
 					//SSHKeys:                   []string{sshKey1, sshKey2},         // 公開鍵(文字列で指定)
 					//SSHKeyIDs:                 []types.ID{types.ID(123456789012)}, // 公開鍵(IDで指定)
 					//IsSSHKeysEphemeral:        false,                              // 公開鍵をさくらのクラウド側で生成した場合にサーバ作成後に該当鍵の削除を行うか

--- a/service/iaas/vpcrouter/builder/builder_nic.go
+++ b/service/iaas/vpcrouter/builder/builder_nic.go
@@ -41,7 +41,7 @@ func (s *StandardNICSetting) getInterfaceSetting() *iaas.VPCRouterInterfaceSetti
 	return nil
 }
 
-// PremiumNICSetting VPCルータのeth0をスイッチ+ルータに接続するためのSetting(プレミアム/ハイスペックプラン)
+// PremiumNICSetting VPCルータのeth0をルータ+スイッチに接続するためのSetting(プレミアム/ハイスペックプラン)
 type PremiumNICSetting struct {
 	SwitchID         types.ID
 	IPAddresses      []string


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

-

### このPRはどういう変更を行いますか？

`スイッチ+ルータ` という表現を `ルータ+スイッチ` という正しいサービス名に変更します。

See https://cloud.sakura.ad.jp/products/router-switch/

### ドキュメントの変更は必要ですか？
