### PR TITLE
common/saclient: allow 1 min time window

### DIFF
--- a/common/saclient/rfc7523.go
+++ b/common/saclient/rfc7523.go
@@ -57,6 +57,7 @@ func (d *doer) inquireAccessToken(ctx context.Context, cfg *config) (*tokenRespo
 	var ret tokenResponse
 	iat := time.Now().Unix()
 	exp := iat + 600 // 10 min
+	nbf := iat - 60  // 1 min
 
 	// these fields are checked beforehand
 	aud := obtainFromConfig[string](cfg, "TokenEndpoint").unwrap()
@@ -84,6 +85,7 @@ func (d *doer) inquireAccessToken(ctx context.Context, cfg *config) (*tokenRespo
 		"sub": sub,
 		"aud": aud,
 		"iat": iat,
+		"nbf": nbf,
 		"exp": exp,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)


### PR DESCRIPTION
クライアントの時計がずれている(早い)ことを許容しようとしています。

See also: [RFC7662](https://www.rfc-editor.org/rfc/rfc7662.html#section-2.2)

なお設定項目はありません。時計が何分もずれる事を設定するくらいなら、その暇でNTPのほうを設定すべきかと思います。