### PR TITLE
common/saclient: add `WithAPIRequestRateLimit`

### DIFF
--- a/common/saclient/client.go
+++ b/common/saclient/client.go
@@ -482,13 +482,10 @@ func isJSONMarshalable(v any) bool {
 
 	if err != nil {
 		return false
+	} else if v, ok := v.(int64); ok {
+		return v != rateLimitWhiteOut
 	} else {
-		switch v.(type) {
-		default:
-			return true
-		case int64:
-			return v.(int64) != rateLimitWhiteOut
-		}
+		return true
 	}
 }
 

--- a/common/saclient/client.go
+++ b/common/saclient/client.go
@@ -480,7 +480,16 @@ func isJSONMarshalable(v any) bool {
 	enc := json.NewEncoder(io.Discard)
 	err := enc.Encode(v)
 
-	return err == nil
+	if err != nil {
+		return false
+	} else {
+		switch v.(type) {
+		default:
+			return true
+		case int64:
+			return v.(int64) != rateLimitWhiteOut
+		}
+	}
 }
 
 var _ ClientAPI = (*Client)(nil)

--- a/common/saclient/client_option.go
+++ b/common/saclient/client_option.go
@@ -201,6 +201,21 @@ func WithDefaultTimeout(t time.Duration) clientOption {
 	}
 }
 
+func WithAPIRequestRateLimit(rate uint16) clientOption {
+	return withAPIRequestRateLimit(int(rate))
+}
+
+func WithoutAPIRequestRateLimit() clientOption {
+	return withAPIRequestRateLimit(-1)
+}
+
+func withAPIRequestRateLimit(rate int) clientOption {
+	return func(c *Client) error {
+		c.params.dynamic.apiRequestRateLimit.initialize(int64(rate))
+		return nil
+	}
+}
+
 func withSettingHeader(key, value string) clientOption {
 	return WithMiddleware(func(req *http.Request, pull func() (Middleware, bool)) (*http.Response, error) {
 		req.Header.Set(key, value)

--- a/common/saclient/client_option.go
+++ b/common/saclient/client_option.go
@@ -202,16 +202,16 @@ func WithDefaultTimeout(t time.Duration) clientOption {
 }
 
 func WithAPIRequestRateLimit(rate uint16) clientOption {
-	return withAPIRequestRateLimit(int(rate))
+	return withAPIRequestRateLimit(int64(rate))
 }
 
 func WithoutAPIRequestRateLimit() clientOption {
-	return withAPIRequestRateLimit(-1)
+	return withAPIRequestRateLimit(rateLimitWhiteOut)
 }
 
-func withAPIRequestRateLimit(rate int) clientOption {
+func withAPIRequestRateLimit(rate int64) clientOption {
 	return func(c *Client) error {
-		c.params.dynamic.apiRequestRateLimit.initialize(int64(rate))
+		c.params.dynamic.apiRequestRateLimit.initialize(rate)
 		return nil
 	}
 }

--- a/common/saclient/client_test.go
+++ b/common/saclient/client_test.go
@@ -513,22 +513,34 @@ func (s *ClientTestSuite) TestDynamic() {
 }
 
 func (s *ClientTestSuite) TestWithAPIRequestRateLimit() {
-	limit := v2.IntN(100) + 32                                            // #nosec G404 -- This is only a test
-	api, err := s.subject.DupWith(WithAPIRequestRateLimit(uint16(limit))) // #nosec G115 -- Overflow never happens
-	s.NoError(err)
-	err = api.Populate()
-	s.NoError(err)
-	subject := api.(*Client)
-	j := subject.JSON()
-	s.Equal(int64(limit), j["APIRequestRateLimit"])
+	s.Run("set", func() {
+		limit := v2.IntN(100) + 32                                            // #nosec G404 -- This is only a test
+		api, err := s.subject.DupWith(WithAPIRequestRateLimit(uint16(limit))) // #nosec G115 -- Overflow never happens
+		s.NoError(err)
+		err = api.Populate()
+		s.NoError(err)
+		subject := api.(*Client)
+		j := subject.JSON()
+		s.Equal(int64(limit), j["APIRequestRateLimit"])
+	})
 
-	api, err = s.subject.DupWith(WithoutAPIRequestRateLimit())
-	s.NoError(err)
-	err = api.Populate()
-	s.NoError(err)
-	subject = api.(*Client)
-	j = subject.JSON()
-	s.NotContains(j, "APIRequestRateLimit")
+	s.Run("without", func() {
+		api, err := s.subject.DupWith(WithoutAPIRequestRateLimit())
+		s.NoError(err)
+		err = api.Populate()
+		s.NoError(err)
+		subject := api.(*Client)
+		j := subject.JSON()
+		s.NotContains(j, "APIRequestRateLimit")
+	})
+
+	s.Run("zero is rejected", func() {
+		api, err := s.subject.DupWith(WithAPIRequestRateLimit(0))
+		s.NoError(err)
+		err = api.Populate()
+		s.Error(err)
+		s.Contains(err.Error(), "can't be zero")
+	})
 }
 
 // #nosec G101 -- This is only a test

--- a/common/saclient/client_test.go
+++ b/common/saclient/client_test.go
@@ -512,6 +512,8 @@ func (s *ClientTestSuite) TestDynamic() {
 	s.Equal("is1c", cfg.Zone)
 }
 
+// #nosec G404 -- This is only a test
+// #nosec G115 -- Overflow never happens
 func (s *ClientTestSuite) TestWithAPIRequestRateLimit() {
 	limit := v2.IntN(100) + 32
 	api, err := s.subject.DupWith(WithAPIRequestRateLimit(uint16(limit)))

--- a/common/saclient/client_test.go
+++ b/common/saclient/client_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	v2 "math/rand/v2"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -509,6 +510,17 @@ func (s *ClientTestSuite) TestDynamic() {
 	cfg, err := api.EndpointConfig()
 	s.NoError(err)
 	s.Equal("is1c", cfg.Zone)
+}
+
+func (s *ClientTestSuite) TestWithAPIRequestRateLimit() {
+	limit := v2.IntN(100) + 32
+	api, err := s.subject.DupWith(WithAPIRequestRateLimit(uint16(limit)))
+	s.NoError(err)
+	err = api.Populate()
+	s.NoError(err)
+	subject := api.(*Client)
+	j := subject.JSON()
+	s.Equal(int64(limit), j["APIRequestRateLimit"])
 }
 
 // #nosec G101 -- This is only a test

--- a/common/saclient/client_test.go
+++ b/common/saclient/client_test.go
@@ -513,9 +513,8 @@ func (s *ClientTestSuite) TestDynamic() {
 }
 
 // #nosec G404 -- This is only a test
-// #nosec G115 -- Overflow never happens
 func (s *ClientTestSuite) TestWithAPIRequestRateLimit() {
-	limit := v2.IntN(100) + 32
+	limit := v2.IntN(100) + 32 // #nosec G115 -- Overflow never happens
 	api, err := s.subject.DupWith(WithAPIRequestRateLimit(uint16(limit)))
 	s.NoError(err)
 	err = api.Populate()
@@ -523,6 +522,14 @@ func (s *ClientTestSuite) TestWithAPIRequestRateLimit() {
 	subject := api.(*Client)
 	j := subject.JSON()
 	s.Equal(int64(limit), j["APIRequestRateLimit"])
+
+	api, err = s.subject.DupWith(WithoutAPIRequestRateLimit())
+	s.NoError(err)
+	err = api.Populate()
+	s.NoError(err)
+	subject = api.(*Client)
+	j = subject.JSON()
+	s.NotContains(j, "APIRequestRateLimit")
 }
 
 // #nosec G101 -- This is only a test

--- a/common/saclient/client_test.go
+++ b/common/saclient/client_test.go
@@ -512,10 +512,9 @@ func (s *ClientTestSuite) TestDynamic() {
 	s.Equal("is1c", cfg.Zone)
 }
 
-// #nosec G404 -- This is only a test
 func (s *ClientTestSuite) TestWithAPIRequestRateLimit() {
-	limit := v2.IntN(100) + 32 // #nosec G115 -- Overflow never happens
-	api, err := s.subject.DupWith(WithAPIRequestRateLimit(uint16(limit)))
+	limit := v2.IntN(100) + 32                                            // #nosec G404 -- This is only a test
+	api, err := s.subject.DupWith(WithAPIRequestRateLimit(uint16(limit))) // #nosec G115 -- Overflow never happens
 	s.NoError(err)
 	err = api.Populate()
 	s.NoError(err)

--- a/common/saclient/http_request_doer.go
+++ b/common/saclient/http_request_doer.go
@@ -45,6 +45,8 @@ type doer struct {
 
 var _ HttpRequestDoer = (*doer)(nil)
 
+const rateLimitWhiteOut = int64(math.MaxInt64) // special value to indicate "no rate limit"
+
 func (d *doer) Do(req *http.Request) (*http.Response, error) {
 	pull, stop := iter.Pull(slices.Values(d.middlewares))
 	defer stop()
@@ -107,6 +109,10 @@ func newHttpRequestDoer(c *config) (HttpRequestDoer, error) {
 	case !ok:
 		d.rateLimiter = ratelimit.NewUnlimited()
 	case v < 0:
+		return nil, NewErrorf("negative APIRequestRateLimit does't make any sense at all: %d", v)
+	case v == 0:
+		return nil, NewErrorf("APIRequestRateLimit can't be zero")
+	case v == rateLimitWhiteOut:
 		d.rateLimiter = ratelimit.NewUnlimited()
 	case v > int64(math.MaxInt):
 		return nil, NewErrorf("APIRequestRateLimit out of range of `int`: %d", v)

--- a/common/saclient/http_request_doer.go
+++ b/common/saclient/http_request_doer.go
@@ -109,7 +109,7 @@ func newHttpRequestDoer(c *config) (HttpRequestDoer, error) {
 	case !ok:
 		d.rateLimiter = ratelimit.NewUnlimited()
 	case v < 0:
-		return nil, NewErrorf("negative APIRequestRateLimit does't make any sense at all: %d", v)
+		return nil, NewErrorf("negative APIRequestRateLimit doesn't make any sense at all: %d", v)
 	case v == 0:
 		return nil, NewErrorf("APIRequestRateLimit can't be zero")
 	case v == rateLimitWhiteOut:

--- a/common/saclient/http_request_doer.go
+++ b/common/saclient/http_request_doer.go
@@ -16,6 +16,7 @@ package saclient
 
 import (
 	"iter"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -102,10 +103,15 @@ func newHttpRequestDoer(c *config) (HttpRequestDoer, error) {
 		return nil, err
 	}
 
-	if ok {
-		d.rateLimiter = ratelimit.New(int(v))
-	} else {
+	switch {
+	case !ok:
 		d.rateLimiter = ratelimit.NewUnlimited()
+	case v < 0:
+		d.rateLimiter = ratelimit.NewUnlimited()
+	case v > int64(math.MaxInt):
+		return nil, NewErrorf("APIRequestRateLimit out of range of `int`: %d", v)
+	default:
+		d.rateLimiter = ratelimit.New(int(v))
 	}
 
 	// basic middlewares


### PR DESCRIPTION
クライアントのレートリミットは現状でも環境変数などから指定可能ですが、プログラム側からロジックで指定したい場合に可能にする新しいオプション`WithAPIRequestRateLimit` (とWithout版)を追加します。

また、これまで負の数を与えた時の挙動が怪しい感じになっていた(ライブラリないも含めて誰もチェックしてない…?)ので、そこも検証するようにしています。